### PR TITLE
Conflict between database users and table partitioning

### DIFF
--- a/modules/Login.database.php
+++ b/modules/Login.database.php
@@ -25,8 +25,13 @@ function halon_login_database($username, $password, $method, $settings)
 	$result['access'] = array();
 	$result['disabled_features'] = array();
 
-	while ($row = $statement->fetch(PDO::FETCH_ASSOC))
-		$result['access'][$row['type']][] = $row['access'];
+	while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+		if ( $row['type'] === 'userid' ) {
+			$result['access'][$row['type']] = $row['access'];
+		} else {
+			$result['access'][$row['type']][] = $row['access'];
+		}
+	}
 
 	$statement = $dbh->prepare("SELECT * FROM users_disabled_features WHERE username = :username;");
 	$statement->execute(array(':username' => $username));


### PR DESCRIPTION
If I insert a record into `users_relations` table with type `userid` the login function `halon_login_database` ([here](https://github.com/halon/sp-enduser/blob/a65cbbde8243a77545dce7ce88610b494e5e3c60/modules/Login.database.php#L28-L29)) loads it into the user's `access` session key as an array, like this:

```php
'access' => [ 
    'userid' => [ 12345 ],
],
```

whereas `Sesssion::getMessagelogTable` expects `['access']['userid']` to be a scalar ([here](https://github.com/halon/sp-enduser/blob/a65cbbde8243a77545dce7ce88610b494e5e3c60/classes/Settings.class.php#L548)). 