### PR TITLE
Allow quarantine and archive to be turned on independently of database-log

### DIFF
--- a/classes/Settings.class.php
+++ b/classes/Settings.class.php
@@ -359,8 +359,6 @@ class Settings
 	 */
 	public function getDisplayQuarantine()
 	{
-		if ($this->getUseDatabaseLog())
-			return false;
 		return $this->displayQuarantine;
 	}
 
@@ -369,8 +367,6 @@ class Settings
 	 */
 	public function getDisplayArchive()
 	{
-		if ($this->getUseDatabaseLog())
-			return false;
 		return $this->displayArchive;
 	}
 


### PR DESCRIPTION
## Problem

When `$settings['database-log'] = true` it is not possible to use the `quarantine` or `archive` views. 

## Solution

Dropping the `if ($this->getUseDatabaseLog())` checks in each of these methods:

 - `Settings::getDisplayQuarantine`
 - `Settings::getDisplayArchive`

Then we can set the flags in `settings.php` to individually enable/disable the features.

## Compatibility

Any installation which has both `$settings['database-log'] = true` and one or more of these settings still set to the default:

 - `display-quarantine`  (`true`)
 - `display-archive`  (`true`)

 will behave differently after this patch is applied (the feature will be enabled instead of disabled).  