### PR TITLE
Allow configuration of the RRD storage path (Settings::getGraphPath)

### DIFF
--- a/classes/Settings.class.php
+++ b/classes/Settings.class.php
@@ -52,6 +52,8 @@ class Settings
 	private $digestToAll = false;
 	private $digestSecret = null;
 	private $sessionName = null;
+
+	private $graphPath = BASE . '/../rrd';
 	
 	/**
 	 * Returns a shared Settings instance.
@@ -114,6 +116,7 @@ class Settings
 		$this->extract($this->twoFactorAuth, 'twofactorauth');
 		$this->extract($this->geoIP, 'geoip');
 		$this->extract($this->geoIPDatabase, 'geoip-database');
+		$this->extract($this->graphPath, 'stats-graph-path');
 
 		foreach ($this->nodeCredentials as $id => $cred) {
 			$username = isset($cred['username']) ? $cred['username'] : null;
@@ -529,7 +532,7 @@ class Settings
 	 */
 	public function getGraphPath()
 	{
-		return BASE . '/../rrd';
+		return $this->graphPath;
 	}
 
 	/**

--- a/settings-default.php
+++ b/settings-default.php
@@ -99,6 +99,14 @@
  */
 //$settings['database-stats'] = false;
 
+/**
+ * Statistical graphs are read from an RRD; this specifies where to find it.
+ * Can be a file path or fully-qualified URL
+ *
+ * Default value: BASE . '/../rrd'
+ */
+//$settings['stats-graph-path'] = '/path/to/rrd';
+
 /*
  * Authentication is probably the second most important configuration
  * directive, as it specifies how end-users should identify themselves.


### PR DESCRIPTION
## Problem

The path to the RRD files is hard-coded into the `Settings` class

## Solution

Add a new setting `stats-graph-path` to the configuration file and return its value through `Settings::getGraphPath`.

## Compatibility

Change is backwards-compatible as the new setting defaults to `BASE . '/../rrd`, as before. 