### PR TITLE
Allow overriding the SOAP connection timeout

### DIFF
--- a/classes/Node.class.php
+++ b/classes/Node.class.php
@@ -8,8 +8,9 @@ class Node
 	private $password;
 	private $serial;
 	private $tls;
+	private $timeout;
 	
-	public function __construct($id, $address, $username = null, $password = null, $serial = null, $tls = array())
+	public function __construct($id, $address, $username = null, $password = null, $serial = null, $tls = array(), $timeout = null)
 	{
 		$this->id = $id;
 		$this->address = $address;
@@ -17,6 +18,7 @@ class Node
 		$this->password = $password;
 		$this->serial = $serial;
 		$this->tls = $tls;
+		$this->timeout = is_numeric($timeout) ? (int)$timeout : 5;
 	}
 	
 	public function soap($async = false, $username = null, $password = null, $serial = null)
@@ -34,7 +36,7 @@ class Node
 			'uri' => 'urn:halon',
 			'login' => $username,
 			'password' => $password,
-			'connection_timeout' => 5,
+			'connection_timeout' => $this->timeout,
 			'features' => SOAP_SINGLE_ELEMENT_ARRAYS,
 			'compression' => SOAP_COMPRESSION_ACCEPT | (SOAP_COMPRESSION_GZIP | 0)
 			);

--- a/classes/Settings.class.php
+++ b/classes/Settings.class.php
@@ -10,6 +10,7 @@ class Settings
 	
 	private $nodeCredentials = array();
 	private $nodes = array();
+	private $nodeDefaultTimeout = 5;
 	private $apiKey = null;
 	private $dbCredentials = array('dns' => null);
 	private $authSources = array(array('type' => 'server'));
@@ -75,6 +76,7 @@ class Settings
 		$this->settings = $settings;
 		
 		$this->extract($this->nodeCredentials, 'node');
+		$this->extract($this->nodeDefaultTimeout, 'node-default-timeout');
 		$this->extract($this->apiKey, 'api-key');
 		$this->extract($this->mailSender, 'mail.from');
 		$this->extract($this->publicURL, 'public-url');
@@ -120,7 +122,8 @@ class Settings
 			$password = isset($cred['password']) ? $cred['password'] : null;
 			$serial = isset($cred['serialno']) ? $cred['serialno'] : null;
 			$tls = isset($cred['tls']) ? $cred['tls'] : array();
-			$this->nodes[] = new Node($id, $cred['address'], $username, $password, $serial, $tls);
+			$timeout = isset($cred['timeout']) ? (int)$cred['timeout'] : $this->nodeDefaultTimeout;
+			$this->nodes[] = new Node($id, $cred['address'], $username, $password, $serial, $tls, $timeout);
 		}
 		
 		if(!$this->publicURL)

--- a/settings-default.php
+++ b/settings-default.php
@@ -18,6 +18,20 @@
  * create specific access rights so that if this end-user web is compromised,
  * your gateways are not. In some cases, even read-only access is good enough
  * for this application.
+ *
+ * The default SOAP connection timeout is 5 seconds.  To change the global
+ * default, set `node-default-timeout` key to the required value
+ *
+ *     $settings['node-default-timeout'] = 10;
+ *
+ * It is also possible to override the connection timeout on a per-node basis
+ * by specifying it in the `timeout` key of the node definition:
+ *
+ *    $settings['node'][] = array(
+ *        'address' => 'https://10.2.0.30/',
+ *        'timeout' => 15,
+ *    );
+ *
  */
 
 //$settings['node'][] = array(


### PR DESCRIPTION
## Problem

The SOAP connection timeout is hard-coded into `Node`.

## Solution

1. Add a new setting `node-default-timeout` which sets the system-wide default SOAP connection timeout.  

2. Support a new key `timeout` in the `node` set, so that connection timeout can be customized per-node.  

## Compatibility

Change is backwards-compatible.