### PR TITLE
Implement deleting of messagelog entries by age

### DIFF
--- a/classes/Settings.class.php
+++ b/classes/Settings.class.php
@@ -48,6 +48,9 @@ class Settings
 	private $twoFactorAuth = false;
 	private $geoIP = false;
 	private $geoIPDatabase = null;
+
+	private $databaseLogCleanType = 'count';
+	private $databaseLogCleanThreshold = 5000000;
 	
 	private $digestToAll = false;
 	private $digestSecret = null;
@@ -102,6 +105,8 @@ class Settings
 		$this->extract($this->displayListener, 'display-listener');
 		$this->extract($this->displayTransport, 'display-transport');
 		$this->extract($this->useDatabaseLog, 'database-log');
+		$this->extract($this->databaseLogCleanType, 'database-log-cleanup.type');
+		$this->extract($this->databaseLogCleanThreshold, 'database-log-cleanup.threshold');
 		$this->extract($this->useDatabaseStats, 'database-stats');
 		$this->extract($this->dbCredentials, 'database');
 		$this->extract($this->authSources, 'authentication');
@@ -598,5 +603,21 @@ class Settings
 		else
 			$tables[] = 'messagelog';
 		return $tables;
+	}
+
+	/**
+	 * Returns the configured method for cleaning out message log tables
+	 */
+	public function getDatabaseLogCleanType()
+	{
+		return $this->databaseLogCleanType;
+	}
+
+	/**
+	 * Returns the configured threshold to use when cleaning out message log tables
+	 */
+	public function getDatabaseLogCleanThreshold()
+	{
+		return $this->databaseLogCleanThreshold;
 	}
 }

--- a/cron/cleanmessagelog.php
+++ b/cron/cleanmessagelog.php
@@ -12,7 +12,11 @@ define('BASE', dirname(__FILE__).'/..');
 require_once BASE.'/inc/core.php';
 require_once BASE.'/inc/utils.php';
 
-$max = 5000000;
+if ( 'count' !== $settings->getDatabaseLogCleanType() ) {
+	die('this message log cleaning method is not active');
+}
+
+$max = (int)$settings->getDatabaseLogCleanThreshold();
 $chunks = 1000;
 
 foreach ($settings->getMessagelogTables() as $table)

--- a/cron/cleanmessagelogbyage.php
+++ b/cron/cleanmessagelogbyage.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Don't invoke directly. Run as:
+ * php cron.php.txt cleanmessagelogbyage
+ */
+
+if (!isset($_SERVER['argc']))
+	die('this file can only be run from command line');
+
+define('BASE', dirname(__FILE__).'/..');
+require_once BASE.'/inc/core.php';
+require_once BASE.'/inc/utils.php';
+
+$dbh = $settings->getDatabase();
+
+if ( 'age' !== $settings->getDatabaseLogCleanType() ) {
+	die('this message log cleaning method is not active');
+}
+
+$retention = (int)$settings->getDatabaseLogCleanThreshold();
+
+foreach ($settings->getMessagelogTables() as $table)
+{
+	$statement = $dbh->prepare('DELETE FROM ' . $table . ' WHERE msgts < (unix_timestamp() - :retention);');
+	$statement->execute([':retention' => $retention]);
+	$deleted = $statement->rowCount();
+	echo "$table: deleted $deleted rows\n";
+}

--- a/settings-default.php
+++ b/settings-default.php
@@ -88,6 +88,22 @@
  */
 //$settings['database-log'] = false;
 
+/**
+ * Log entries stored in the central database server can be cleaned up periodically
+ * based on one of two criteria
+ *
+ *  - "count": total number of records in each table
+ *  - "age": total number of seconds elapsed since the record was created
+ *
+ * A cron script is provided to implement each type of cleanup:
+ *
+ *  - "count": `php cron.php.txt cleanmessagelog`
+ *  - "age": `php cron.php.txt cleanmessagelogbyage`
+ *
+ */
+//$settings['database-log-cleanup'] = [ 'type' => 'count', 'threshold' => 5000000 ];
+//$settings['database-log-cleanup'] = [ 'type' => 'age', 'threshold' => (3600*24*14) ];
+
 /*
  * Stats are normally read from the nodes directly, but for performance, you can
  * instead opt to configure your nodes to stat to a central database server, as


### PR DESCRIPTION
## Problem

We need predictable retention time for messagelog entries.

## Solution

This patch adds a new cron script `cleanmessagelogbyage` which deletes any message logs created more than the configured number of seconds ago.  

We have found the best result is to run this script every minute via cron, so as to keep the number of issued delete statements as small as possible.

## Compatibility

Change is not backwards-compatible in one case:  [this line](https://github.com/halon/sp-enduser/blob/55eaa5e1c250a723ad94e8ee4169b11fef2d27da/cron/cleanmessagelog.php#L15) has been modified directly in the downstream version (as we did, initially).  The developer will need to move their custom `$max` into `$settings['database-log-cleanup']['threshold']` else the system will revert back to the original 5M-record threshold. 