### PR TITLE
Fix a hard-coded node index in "rates" section of xhr.php

### DIFF
--- a/settings-default.php
+++ b/settings-default.php
@@ -220,6 +220,7 @@
 //		'count_limit' => 100,			// At which number the limit is exceeded 
 //		'action' => 'DEFER',			// Action taken if limit is exceeded
 //		'search_filter' => 'from=$entry',	// Search filter for the "messages" page
+//		'node' => 0,				// Index of the node in $settings['nodes'] on which to run the query
 //		);
 
 /*

--- a/xhr.php
+++ b/xhr.php
@@ -226,7 +226,8 @@ if ($_POST['page'] == 'rates')
 		if (!isset($ratelimits[$_POST['rate']])) die(json_encode(array('error' => 'Invalid ratelimit')));
 		$rate = $ratelimits[$_POST['rate']];
 
-		$nodeBackend = new NodeBackend($settings->getNode(0));
+		$nodeIndex = isset($rate['node']) ? (int)$rate['node'] : 0;
+		$nodeBackend = new NodeBackend($settings->getNode($nodeIndex));
 
 		// Compensate for count being '> X' in the API
 		if (isset($rate['count_min']))


### PR DESCRIPTION
## Problem

`xhr.php` has a hard-coded reference to index 0 when selecting the node to load counters from:

https://github.com/halon/sp-enduser/blob/9f29e7aeb97d25454617290007ed96fb082d4b62/xhr.php#L229

In the case where `sp-enduser` is configured to read from nodes in two or more distinct clusters this makes it impossible to read counters from any cluster other than the one the node at index 0 belongs to. 

## Solution

In `settings.php`, allow specifying the index of the node to load each rate limit counter from.  Example:

```
$settings['ratelimits'][] = array(
    'ns' => 'outbound-spam',
    'name' => 'Outbound spammers (Last 8 hours)',
    'count_min' => 10,
    'count_limit' => 50,
    'action' => 'DEFER',
    'search_filter' => 'sasl=$entry',
    'node' => 7
);
```

In this example, the counter `outbound-spam` will be read from the host configured in `$settings['node'][7]`

## Compatibility

Fully backwards-compatible.  If the `ratelimits` entry has no `node` key then `xhr.php` will fall back to using node 0.
